### PR TITLE
Add new parametres in Docx Viewer (FilePath, File, Bytes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Docx_Viewer
 
 A Flutter package for displaying DOCX files as text in your app. This package uses the `docx_to_text` package to read DOCX files and display their content as text.
@@ -48,8 +47,11 @@ void main() {
 }
 ```
 
-### Parameters:
-- `filePath`: The path to the DOCX file to display (required).
+### Parameters
+##### You must provide either `filePath`, `file`, or `bytes`
+- `filePath`: The path to the DOCX file to display.
+- `file`: The DOCX file to display.
+- `bytes`: DOCX bytes to display.
 - `fontSize`: The font size for displaying the text (optional, default is 16).
 - `onError`: A callback to handle errors if the file can't be loaded (optional).
 
@@ -84,4 +86,3 @@ If you find this package helpful and would like to support its development, cons
 
 
 ### Thank you for your support!
-

--- a/lib/src/docx_view.dart
+++ b/lib/src/docx_view.dart
@@ -1,4 +1,6 @@
+import 'dart:typed_data';
 import 'dart:io';
+
 import 'package:docx_viewer/src/extract_text_from_docx.dart';
 import 'package:docx_viewer/utils/support_type.dart';
 import 'package:flutter/material.dart';
@@ -12,23 +14,32 @@ import 'package:http/http.dart' as http;
 /// Supported document types:
 /// - DOCX: Displayed as text after converting from DOCX binary format using the [docx_to_text] package.
 ///
-/// Example usage:
+/// Examples usages:
 /// ```dart
 /// DocxView(filePath: '/path/to/your/document.docx')
+/// DocxView(file: docxFile)
+/// DocxView(bytes: docxBytes)
 /// ```
 class DocxView extends StatefulWidget {
-  final String filePath; // The path to the DOCX file or URL
+  final String? filePath; // The path to the DOCX file or URL
+  final File? file; // The DOCX file
+  final Uint8List? bytes; // The bytes of one DOCX file
   final int fontSize; // Optional font size for displaying the text
   final Function(Exception)? onError; // Optional callback for handling errors
 
   /// Creates a [DocxView] widget.
   ///
-  /// [filePath] is required, representing the path or URL of the DOCX file to display.
+  /// Required to define filePath or file or bytes`
+  /// [filePath] representing the path or URL of the DOCX file to display.
+  /// [file] the file to display
+  /// [bytes] docx bytes to display
   /// [fontSize] is optional and defaults to 16 if not specified.
   /// [onError] is an optional callback for handling errors.
   const DocxView({
     super.key,
-    required this.filePath,
+    this.filePath,
+    this.file,
+    this.bytes,
     this.fontSize = 16,
     this.onError,
   });
@@ -51,23 +62,47 @@ class _DocxViewState extends State<DocxView> {
   /// Validates the file path, determines if it's a network or local file, and loads the DOCX content.
   Future<void> _validateAndLoadDocxContent() async {
     // Check if the file path is empty
-    if (widget.filePath.isEmpty) {
-      _handleError(Exception("File path is empty."));
+    if ((widget.filePath == null || widget.filePath!.isEmpty) &&
+    	widget.file == null && widget.bytes == null) {
+      _handleError(Exception("File path is empty. there isn't file and bytes not defined"));
+      return;
+    }
+
+    if (((widget.bytes != null) && (widget.file != null || widget.filePath != null)) ||
+        ((widget.file != null) && (widget.filePath != null))) {
+      _handleError(Exception("Define only filePath, file or bytes"));
       return;
     }
 
     // Check if the filePath is a network URL or a local file path
-    if (widget.filePath.startsWith('http')) {
+    if (widget.filePath != null && widget.filePath!.startsWith('http')) {
       // Load content from a network file
-      await _loadDocxContentFromNetwork(widget.filePath);
-    } else {
+      await _loadDocxContentFromNetwork(widget.filePath!);
+    } else if (widget.bytes != null){
+      // Extract Text directly from bytes
+      await _loadDocxBytesContent(widget.bytes!);
+    }
+    else {
       // Load content from a local file
-      final file = File(widget.filePath);
+      final file = widget.file ?? File(widget.filePath!);
       if (!(await file.exists())) {
         _handleError(Exception("File not found: ${widget.filePath}"));
         return;
       }
       await _loadDocxContent(file);
+    }
+  }
+
+  /// Loads the content from bytes of Docx file stored locally
+  Future<void> _loadDocxBytesContent(Uint8List bytes) async {
+    try {
+      final content = extractTextFromDocxBytes(bytes);
+      setState(() {
+        fileContent = content;
+        isLoading = false;
+      });
+    } catch (e) {
+      _handleError(Exception("Error reading file: ${e.toString()}"));
     }
   }
 

--- a/lib/src/docx_view.dart
+++ b/lib/src/docx_view.dart
@@ -64,7 +64,7 @@ class _DocxViewState extends State<DocxView> {
     // Check if the file path is empty
     if ((widget.filePath == null || widget.filePath!.isEmpty) &&
     	widget.file == null && widget.bytes == null) {
-      _handleError(Exception("File path is empty. there isn't file and bytes not defined"));
+      _handleError(Exception("No input provided. You must specify either filePath, file, or bytes."));
       return;
     }
 

--- a/lib/src/docx_view.dart
+++ b/lib/src/docx_view.dart
@@ -68,6 +68,7 @@ class _DocxViewState extends State<DocxView> {
       return;
     }
 
+    // Ensure that only one of the three parameters bytes, file or filePath is provided.
     if (((widget.bytes != null) && (widget.file != null || widget.filePath != null)) ||
         ((widget.file != null) && (widget.filePath != null))) {
       _handleError(Exception("Define only filePath, file or bytes"));

--- a/lib/src/extract_text_from_docx.dart
+++ b/lib/src/extract_text_from_docx.dart
@@ -1,14 +1,20 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:archive/archive.dart';
 import 'package:xml/xml.dart' as xml;
 import 'dart:convert';
 
-/// Extracts text content from a DOCX file.
+/// Read bytes in file and send it to become ZIP archive
 String extractTextFromDocx(File file) {
+    return extractTextFromDocxBytes(file.readAsBytesSync());
+}
+
+/// Extracts text content from a DOCX file.
+String extractTextFromDocxBytes(Uint8List bytes) {
   final List<String> extractedText = [];
 
-  // Read and decode the DOCX file as a ZIP archive
-  final archive = ZipDecoder().decodeBytes(file.readAsBytesSync());
+  // Decode the DOCX bytes as a ZIP archive
+  final archive = ZipDecoder().decodeBytes(bytes);
 
   // Find the main document file in the DOCX archive
   final documentFile = archive.files.firstWhere(


### PR DESCRIPTION
This commit improves compatibility with Flutter Web and the FileReader Library, making it easier to select a file and feed a DOCX’s raw bytes directly. You can still choose to load a DOCX via its path or a File.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded DOCX viewer widget to support loading documents from a file path, a file object, or raw bytes, providing greater flexibility for users.

* **Documentation**
  * Updated README to clarify input options for the DOCX viewer and improved parameter descriptions and formatting for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->